### PR TITLE
Split out Prereview.org and OSrPRE import scripts, make couchdb backups automatic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1224,6 +1224,70 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@cloudant/cloudant": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@cloudant/cloudant/-/cloudant-4.3.0.tgz",
+      "integrity": "sha512-duBlUEQID63QZM1CTzSxzCl5k6K+ylfm+lJcziC3CZ3mzUQndoFD0ZdQTq6XNWKNZacnhVXOpEUT2GMeDQCLvQ==",
+      "requires": {
+        "@types/request": "^2.48.4",
+        "async": "2.1.2",
+        "concat-stream": "^1.6.0",
+        "cookie": "^0.4.0",
+        "debug": "^3.1.0",
+        "lockfile": "1.0.3",
+        "nano": "~8.2.2",
+        "request": "^2.81.0",
+        "tmp": "0.0.33"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.1.2.tgz",
+          "integrity": "sha1-YSpKtF70KnDN6Aa62G7m2wR+g4U=",
+          "requires": {
+            "lodash": "^4.14.0"
+          }
+        },
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "@cloudant/couchbackup": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@cloudant/couchbackup/-/couchbackup-2.6.0.tgz",
+      "integrity": "sha512-eyqLrbDoO9O1ECGZLLORqcuei3gfURqIBC4uUnwhvk0nWOobNF27satV/sDj/GKf3WMw3WWQfiq9Cjkq2yvZWQ==",
+      "requires": {
+        "@cloudant/cloudant": "^4.3.0",
+        "async": "^3.1.0",
+        "commander": "^5.0.0",
+        "debug": "~4.1.0",
+        "tmp": "0.2.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "tmp": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+          "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+          "requires": {
+            "rimraf": "^3.0.0"
+          }
+        }
+      }
+    },
     "@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -10900,6 +10964,11 @@
         "@types/node": "*"
       }
     },
+    "@types/caseless": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
+      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
+    },
     "@types/classnames": {
       "version": "2.2.11",
       "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.2.11.tgz",
@@ -11398,6 +11467,29 @@
         "@types/prismjs": "*"
       }
     },
+    "@types/request": {
+      "version": "2.48.5",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.5.tgz",
+      "integrity": "sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==",
+      "requires": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -11449,6 +11541,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/throttle-debounce/-/throttle-debounce-2.1.0.tgz",
       "integrity": "sha512-5eQEtSCoESnh2FsiLTxE121IiE60hnMqcb435fShf4bpLRjEu1Eoekht23y6zXS9Ts3l+Szu3TARnTsA0GkOkQ=="
+    },
+    "@types/tough-cookie": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A=="
     },
     "@types/treeify": {
       "version": "1.0.0",
@@ -12096,6 +12193,11 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "async": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
+    },
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
@@ -12734,6 +12836,11 @@
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
     },
+    "browser-request": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz",
+      "integrity": "sha1-ns5bWsqJopkyJC4Yv5M975h2zBc="
+    },
     "browser-resolve": {
       "version": "1.11.3",
       "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
@@ -12863,8 +12970,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "buffer-writer": {
       "version": "2.0.0",
@@ -13551,6 +13657,16 @@
         "mimic-response": "^1.0.0"
       }
     },
+    "cloudant-follow": {
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/cloudant-follow/-/cloudant-follow-0.18.2.tgz",
+      "integrity": "sha512-qu/AmKxDqJds+UmT77+0NbM7Yab2K3w0qSeJRzsq5dRWJTEJdWeb+XpG4OpKuTE9RKOa/Awn2gR3TTnvNr3TeA==",
+      "requires": {
+        "browser-request": "~0.3.0",
+        "debug": "^4.0.1",
+        "request": "^2.88.0"
+      }
+    },
     "clsx": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
@@ -13731,6 +13847,51 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "concurrently": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-5.3.0.tgz",
@@ -13892,6 +14053,11 @@
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
+    },
+    "cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
     },
     "cookiejar": {
       "version": "2.1.2",
@@ -15085,6 +15251,11 @@
       "requires": {
         "stackframe": "^1.1.1"
       }
+    },
+    "errs": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/errs/-/errs-0.3.2.tgz",
+      "integrity": "sha1-eYCZstvTfKK8dJ5TinwTB9C1BJk="
     },
     "es-abstract": {
       "version": "1.17.7",
@@ -22095,6 +22266,11 @@
         "p-locate": "^4.1.0"
       }
     },
+    "lockfile": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.3.tgz",
+      "integrity": "sha1-Jjj8OaAzHpysGgS3F5mTHJxQ33k="
+    },
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
@@ -22949,6 +23125,18 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+    },
+    "nano": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/nano/-/nano-8.2.3.tgz",
+      "integrity": "sha512-nubyTQeZ/p+xf3ZFFMd7WrZwpcy9tUDrbaXw9HFBsM6zBY5gXspvOjvG2Zz3emT6nfJtP/h7F2/ESfsVVXnuMw==",
+      "requires": {
+        "@types/request": "^2.48.4",
+        "cloudant-follow": "^0.18.2",
+        "debug": "^4.1.1",
+        "errs": "^0.3.2",
+        "request": "^2.88.0"
+      }
     },
     "nano-css": {
       "version": "5.3.0",
@@ -24539,12 +24727,29 @@
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
       "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
     },
+    "p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "requires": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      }
+    },
     "p-some": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/p-some/-/p-some-2.0.1.tgz",
       "integrity": "sha1-Zdh8ixVO289SIdFnd4ttLhUPbwY=",
       "requires": {
         "aggregate-error": "^1.0.0"
+      }
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "requires": {
+        "p-finally": "^1.0.0"
       }
     },
     "p-try": {
@@ -27436,7 +27641,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -29688,6 +29892,11 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
       "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,10 @@
     "watch:backend:dev": "parcel watch --target=backend --no-cache src/backend/index.js",
     "build:frontend": "parcel build --target=frontend src/frontend/index.html",
     "build:frontend:dev": "parcel build --target=frontend --no-minify src/frontend/index.html",
-    "build:scripts:import": "parcel build --target=import-script --no-scope-hoist --no-minify --no-cache src/backend/scripts/dbImport.js",
+    "build:scripts:import": "npm run build:scripts:import:prereview && npm run build:scripts:import:osrpre && npm run build:scripts:couchdb",
+    "build:scripts:import:prereview": "parcel build --target=prereview-import-script --no-scope-hoist --no-minify --no-cache src/backend/scripts/dbImportPrereviewOrg.js",
+    "build:scripts:import:osrpre": "parcel build --target=osrpre-import-script --no-scope-hoist --no-minify --no-cache src/backend/scripts/dbImportOSrPRE.js",
+    "build:scripts:couchdb": "parcel build --target=couchdb-backup-script --no-scope-hoist --no-minify --no-cache src/backend/scripts/couchDbBackup.js",
     "build:scripts:migrations": "npm run scan:migrations && parcel build --target=migrations-script --no-scope-hoist --no-minify --no-cache src/backend/scripts/dbMigrations.ts",
     "build:scripts:seeds": "parcel build --target=seeds-script --no-scope-hoist --no-minify --no-cache src/backend/scripts/dbSeeds.ts",
     "build:scripts:init": "parcel build --target=init-script --no-scope-hoist --no-minify --no-cache src/backend/scripts/dbInit.ts",
@@ -48,7 +51,10 @@
     "db:migrations:test": "ts-node src/backend/scripts/dbMigrations.ts",
     "db:seeds": "ts-node src/backend/scripts/dbSeeds.ts",
     "db:init": "node dist/scripts/dbInit.js",
-    "db:import": "node dist/scripts/dbImport.js",
+    "db:import:prereview": "node dist/scripts/dbImportPrereviewOrg.js",
+    "db:import:osrpre": "node dist/scripts/dbImportOSrPRE.js",
+    "db:import": "npm run db:import:prereview && npm run db:couchdb && npm run db:import:osrpre",
+    "db:couchdb": "node dist/scripts/couchDbBackup.js",
     "scan:migrations": "barrelsby --delete -l below -d src/backend/db/migrations",
     "start:backend": "node dist/backend/index.js",
     "start:backend:dev": "nodemon -w dist/backend --enable-source-maps dist/backend/index.js -p 3001",
@@ -60,7 +66,9 @@
   },
   "backend": "dist/backend/index.js",
   "frontend": "dist/frontend/index.html",
-  "import-script": "dist/scripts/dbImport.js",
+  "prereview-import-script": "dist/scripts/dbImportPrereviewOrg.js",
+  "osrpre-import-script": "dist/scripts/dbImportOSrPRE.js",
+  "couchdb-backup-script": "dist/scripts/couchDbBackup.js",
   "migrations-script": "dist/scripts/dbMigrations.js",
   "seeds-script": "dist/scripts/dbSeeds.js",
   "init-script": "dist/scripts/dbInit.js",
@@ -73,7 +81,15 @@
       "context": "browser",
       "distDir": "dist/frontend"
     },
-    "import-script": {
+    "osrpre-import-script": {
+      "context": "node",
+      "distDir": "dist/scripts"
+    },
+    "prereview-import-script": {
+      "context": "node",
+      "distDir": "dist/scripts"
+    },
+    "couchdb-backup-script": {
       "context": "node",
       "distDir": "dist/scripts"
     },
@@ -103,6 +119,7 @@
     "inlineEnvironment": false
   },
   "dependencies": {
+    "@cloudant/couchbackup": "^2.6.0",
     "@date-io/date-fns": "^1.3.13",
     "@koa/cors": "2.2.3",
     "@koa/router": "^8.0.6",
@@ -180,6 +197,7 @@
     "ndjson": "^2.0.0",
     "node-fetch": "^2.6.1",
     "orcid-utils": "^1.0.4",
+    "p-queue": "^6.6.2",
     "passport-local": "^1.0.0",
     "passport-orcid": "0.0.4",
     "passport-strategy": "^1.0.0",

--- a/src/backend/models/entities/RapidReview.ts
+++ b/src/backend/models/entities/RapidReview.ts
@@ -80,4 +80,10 @@ export class RapidReview extends BaseEntity {
   @Fixture(faker => faker.lorem.sentence())
   @Property({ columnType: 'text', nullable: true })
   linkToData?: string;
+
+  constructor(author: Persona, preprint: Preprint) {
+    super();
+    this.author = author;
+    this.preprint = preprint;
+  }
 }

--- a/src/backend/scripts/couchDbBackup.js
+++ b/src/backend/scripts/couchDbBackup.js
@@ -1,0 +1,36 @@
+import couchbackup from '@cloudant/couchbackup';
+import fs from 'fs';
+//COUCH_URL=${COUCH_PROTOCOL}//${COUCH_USERNAME}:${COUCH_PASSWORD}@${COUCH_HOST}:${COUCH_PORT}
+couchbackup.backup(
+  `https://${process.env.COUCH_USERNAME}:${process.env.COUCH_PASSWORD}@${
+    process.env.COUCH_HOST
+  }:${process.env.COUCH_PORT}/rapid-prereview-docs`,
+  fs.createWriteStream(
+    `${process.env.COUCH_OUTDIR}/rapid-prereview-docs.jsonl`,
+  ),
+  { parallelism: 2 },
+  (err, data) => {
+    if (err) {
+      console.error('Failed! ', err);
+    } else {
+      console.error('Success! ', data);
+    }
+  },
+);
+
+couchbackup.backup(
+  `https://${process.env.COUCH_USERNAME}:${process.env.COUCH_PASSWORD}@${
+    process.env.COUCH_HOST
+  }:${process.env.COUCH_PORT}/rapid-prereview-users`,
+  fs.createWriteStream(
+    `${process.env.COUCH_OUTDIR}/rapid-prereview-users.jsonl`,
+  ),
+  { parallelism: 2 },
+  (err, data) => {
+    if (err) {
+      console.error('Failed! ', err);
+    } else {
+      console.error('Success! ', data);
+    }
+  },
+);

--- a/src/backend/scripts/dbImportOSrPRE.js
+++ b/src/backend/scripts/dbImportOSrPRE.js
@@ -1,0 +1,444 @@
+import fs from 'fs';
+import _ from 'lodash';
+import ndjson from 'ndjson';
+import { dbWrapper } from '../db.ts';
+import {
+  fullReviewModelWrapper,
+  personaModelWrapper,
+  preprintModelWrapper,
+  rapidReviewModelWrapper,
+  requestModelWrapper,
+  userModelWrapper,
+} from '../models/index.ts';
+import anonymus from 'anonymus';
+import { resolvePreprint } from '../utils/resolve.ts';
+import { getOrcidPerson, getOrcidWorks } from '../utils/orcid.js';
+import {
+  Contact,
+  FullReview,
+  FullReviewDraft,
+  Persona,
+  Preprint,
+  RapidReview,
+  Request,
+  User,
+  Work,
+} from '../models/entities/index.ts';
+import PQueue from 'p-queue';
+
+const queue = new PQueue({ concurrency: 1 });
+
+const processJsonDump = (path, cb) => {
+  return new Promise((resolve, reject) => {
+    fs.createReadStream(path)
+      .pipe(ndjson.parse())
+      .on('end', resolve)
+      .on('error', reject)
+      .on('data', obj => cb(obj));
+  });
+};
+
+const processUsers = (path, userHandler) => {
+  const processJsonArray = obj => {
+    obj.map(async item => {
+      if (item['@type'] === 'Person') {
+        console.log(`inserting person ${item['@id']}`);
+        queue.add(async () => await userHandler(item));
+      }
+    });
+  };
+  return processJsonDump(path, processJsonArray);
+};
+
+const processPersonas = (path, anonMap) => {
+  const processJsonArray = obj => {
+    obj.map(item => {
+      if (item['@type'] === 'AnonymousReviewerRole') {
+        console.log(`inserting role ${item['@id']}`);
+        anonMap.set(item['@id'], true);
+      } else if (item['@type'] === 'PublicReviewerRole') {
+        console.log(`inserting role ${item['@id']}`);
+        anonMap.set(item['@id'], false);
+      }
+    });
+  };
+  return processJsonDump(path, processJsonArray);
+};
+
+const processActions = (path, requestHandler, reviewHandler) => {
+  const processJsonArray = obj => {
+    obj.map(async item => {
+      if (item['@type'] === 'RequestForRapidPREreviewAction') {
+        console.log(`inserting request ${item['@id']}`);
+        queue.add(async () => await requestHandler(item));
+      } else if (item['@type'] === 'RequestForRapidPREreviewAction') {
+        console.log(`inserting review ${item['@id']}`);
+        await reviewHandler(item);
+      }
+    });
+  };
+  return processJsonDump(path, processJsonArray);
+};
+
+async function OSrPREImportReview(
+  fullReviewModel,
+  preprintModel,
+  rapidReviewModel,
+  personasMap,
+) {
+  return async record => {
+    try {
+      const persona = personasMap.get(record.agent);
+      if (!persona) {
+        throw new Error('No persona');
+      }
+      const preprint = await OSrPREImportPreprint(record.object, preprintModel);
+      if (!preprint) {
+        throw new Error('No preprint');
+      }
+      let full;
+      const rapid = new RapidReview(persona, preprint);
+      record.resultReview.reviewAnswer.map(answer => {
+        const key = answer.parentItem.split(':')[1];
+        if (key.startsWith('yn')) {
+          if (answer.text === 'n.a.') {
+            answer.text = 'N/A';
+          }
+          rapid[`${key}`] = answer.text;
+        } else if (key.startsWith('c') && answer.text) {
+          if (!full) {
+            full = 'Imported from Outbreak Science:\n';
+          }
+          full = full.concat(`${key}:\n ${answer.text}`);
+        }
+      });
+      await rapidReviewModel.persistAndFlush(rapid);
+      if (full) {
+        const review = new FullReview(preprint, true);
+        const draft = new FullReviewDraft(review, full);
+        review.drafts.add(draft);
+        review.createdAt = new Date(record.startTime);
+        review.authors.add(persona);
+        await fullReviewModel.persistAndFlush(review);
+      }
+      return;
+    } catch (err) {
+      console.error('Failed to import review:', err);
+    }
+  };
+}
+
+async function OSrPREImportRequest(requestModel, preprintModel, personasMap) {
+  return async record => {
+    try {
+      const persona = personasMap.get(record.agent);
+      if (!persona) {
+        throw new Error('No persona');
+      }
+      const preprint = await OSrPREImportPreprint(record.object, preprintModel);
+      if (!preprint) {
+        throw new Error('No preprint');
+      }
+      const request = new Request(persona, preprint);
+      await requestModel.persistAndFlush(request);
+    } catch (err) {
+      console.error('Failed to import request:', err);
+    }
+  };
+}
+
+async function OSrPREImportPreprint(record, preprintModel) {
+  try {
+    record.createdAt = new Date(record.createdAt);
+    record.datePosted = new Date(record.datePosted);
+    let handle, lookup;
+    if (record.doi) {
+      lookup = await resolvePreprint(record.doi);
+      handle = `doi:${record.doi}`;
+    } else if (record.arXivId) {
+      lookup = await resolvePreprint(record.arXivId);
+      handle = `arxiv:${record.arXivId}`;
+    } else {
+      console.log('ERROR');
+    }
+    let preprint = await preprintModel.findOne({ handle: handle });
+    if (!preprint) {
+      let source;
+      if (lookup) {
+        source = lookup;
+      } else {
+        console.warn(`OSrPRE: Failed to lookup preprint, using data as-is`);
+        source = record;
+      }
+      preprint = new Preprint(
+        handle,
+        source.title,
+        true,
+        source.abstractText,
+        source.preprintServer,
+        source.datePosted,
+        source.license,
+        source.publication,
+        source.url,
+        source.contentEncoding,
+        source.contentUrl,
+      );
+      await preprintModel.persistAndFlush(preprint);
+      console.log(`OSrPRE: Inserted Preprint ${preprint.handle}`);
+    } else {
+      console.log(`OSrPRE: Duplicate preprint ${handle}, skipping`);
+    }
+    console.log('OSrPRE: Flushing preprints to disk.');
+    //await preprintModel.flush();
+    console.log('OSrPRE: Done flushing preprints to disk.');
+    return preprint;
+  } catch (err) {
+    console.error('Failed to import:', err);
+  }
+}
+
+async function OSrPREImportUser(
+  userModel,
+  personaModel,
+  usersMap,
+  personasMap,
+  isAnon,
+) {
+  return async record => {
+    try {
+      record.createdAt = new Date(record.dateCreated);
+      let person, works;
+      try {
+        person = await getOrcidPerson(record.orcid);
+      } catch (err) {
+        console.log('OSrPRE: Failed to fetch ORCID person:', err);
+      }
+      try {
+        works = await getOrcidWorks(record.orcid);
+      } catch (err) {
+        console.log('OSrPRE: Failed to fetch ORCID works:', err);
+      }
+
+      // Process the deep JSON structure for a given ORCID user
+      let userObject;
+      if (person) {
+        userObject = new User(record.orcid);
+        //userObject.createdAt = new Date(record.createdAt);
+        let name;
+        if (person.name) {
+          if (person.name['credit-name'] && person.name['credit-name'].value) {
+            name = person.name['credit-name'].value;
+          } else {
+            name =
+              person.name['given-names'] && person.name['given-names'].value
+                ? person.name['given-names'].value
+                : '';
+            if (
+              person.name['family-name'] &&
+              person.name['family-name'].value
+            ) {
+              name = name.concat(' ', person.name['family-name'].value);
+            }
+          }
+        } else {
+          name = record.name;
+        }
+
+        if (record.hasRole && Array.isArray(record.hasRole)) {
+          record.hasRole.map(async id => {
+            if (isAnon.get(id) === false) {
+              const personaObject = new Persona(name, userObject);
+              if (person.biography && person.biography['content']) {
+                personaObject.bio = person.biography['content'];
+              }
+              userObject.personas.add(personaObject);
+              if (!person.is_private) {
+                userObject.isPrivate = false;
+                userObject.defaultPersona = personaObject;
+              }
+              personasMap.set(id, personaObject);
+            } else if (isAnon.get(id) === true) {
+              let anonName = anonymus.create()[0];
+              while (
+                (await personaModel.findOne({ name: anonName })) !== null
+              ) {
+                console.log('OSrPRE: Anonymous name generation collision');
+                anonName = anonymus.create()[0];
+              }
+              const anonPersonaObject = new Persona(anonName, userObject, true);
+              if (person.is_private) {
+                userObject.isPrivate = true;
+                userObject.defaultPersona = anonPersonaObject;
+              }
+              personasMap.set(id, anonPersonaObject);
+            } else {
+              console.warn(`No such role ${id} mapped`);
+            }
+          });
+        }
+
+        let emails = [];
+        if (
+          record.contactPoint &&
+          record.contactPoint.email &&
+          record.contactPoint['@type'] === 'ContactPoint'
+        ) {
+          let address = record.contactPoint.email.replace(/^mailto:/, '');
+          emails.push({
+            value: address,
+            verified: true,
+          });
+        }
+        if (
+          Array.isArray(person.emails.email) &&
+          person.emails.email.length > 0
+        ) {
+          for (let e of person.emails.email) {
+            emails.push({
+              value: e.email,
+              verified: !!e.verified,
+            });
+          }
+        }
+        if (emails.length > 0) {
+          emails = _.uniq(emails);
+          for (let e of emails) {
+            const contact = new Contact(
+              'mailto',
+              e.value,
+              userObject,
+              !!e.verified,
+            );
+            userObject.contacts.add(contact);
+          }
+          console.log(`OSrPRE: Imported email for ${record.orcid}:`, emails);
+        }
+        console.log(`OSrPRE: Imported user for ${record.orcid}:`, {
+          orcid: record.orcid,
+          createdAt: record.dateCreated,
+        });
+      }
+
+      // Process the deep JSON structure for a given ORCID user's published works
+      if (works && person) {
+        for (let w of works.group) {
+          if (Array.isArray(w['work-summary']) && w['work-summary'].length) {
+            let title;
+            if (
+              w['work-summary'][0].title &&
+              w['work-summary'][0].title.title &&
+              w['work-summary'][0].title.title.value
+            ) {
+              title = w['work-summary'][0].title.title.value;
+            }
+            const work = new Work(title, userObject);
+            if (w['work-summary'][0].url && w['work-summary'][0].url.value) {
+              work.url = w['work-summary'][0].url.value;
+            }
+            if (
+              w['work-summary'][0]['external-ids'] &&
+              Array.isArray(
+                w['work-summary'][0]['external-ids']['external-id'],
+              ) &&
+              w['work-summary'][0]['external-ids']['external-id'].length > 0
+            ) {
+              work.handle = `${
+                w['work-summary'][0]['external-ids']['external-id'][0][
+                  'external-id-type'
+                ]
+              }:${
+                w['work-summary'][0]['external-ids']['external-id'][0][
+                  'external-id-value'
+                ]
+              }`;
+            }
+            if (w['work-summary'][0].type) {
+              work.type = w['work-summary'][0].type;
+            }
+            if (
+              w['work-summary'][0]['publication-date'] &&
+              w['work-summary'][0]['publication-date'].year &&
+              w['work-summary'][0]['publication-date'].year.value
+            ) {
+              let dateString =
+                w['work-summary'][0]['publication-date'].year.value;
+              if (
+                w['work-summary'][0]['publication-date'].month &&
+                w['work-summary'][0]['publication-date'].month.value
+              ) {
+                dateString = dateString.concat(
+                  '-',
+                  w['work-summary'][0]['publication-date'].month.value,
+                );
+              }
+              if (
+                w['work-summary'][0]['publication-date'].day &&
+                w['work-summary'][0]['publication-date'].day.value
+              ) {
+                dateString = dateString.concat(
+                  '-',
+                  w['work-summary'][0]['publication-date'].day.value,
+                );
+              }
+              let publicationDate = new Date(dateString);
+              work.publicationDate = !isNaN(publicationDate)
+                ? publicationDate
+                : undefined;
+            }
+            if (
+              w['work-summary'][0]['journal-title'] &&
+              w['work-summary'][0]['journal-title'].value
+            ) {
+              work.publisher = w['work-summary'][0]['journal-title'].value;
+            }
+            userObject.works.add(work);
+          }
+        }
+      }
+      await userModel.persistAndFlush(userObject);
+      usersMap.set(record['@id'], userObject);
+      return;
+    } catch (err) {
+      console.error('OSrPRE: Failed to import:', err);
+    }
+  };
+}
+
+async function main() {
+  const userMap = new Map();
+  const personaMap = new Map();
+  const anonMap = new Map();
+  const [db] = await dbWrapper();
+  const fullReviewModel = fullReviewModelWrapper(db);
+  const personaModel = personaModelWrapper(db);
+  const preprintModel = preprintModelWrapper(db);
+  const rapidReviewModel = rapidReviewModelWrapper(db);
+  const requestModel = requestModelWrapper(db);
+  const userModel = userModelWrapper(db);
+  await processPersonas(
+    `${process.env.COUCH_OUTDIR}/rapid-prereview-docs.jsonl`,
+    anonMap,
+  );
+  await processUsers(
+    `${process.env.COUCH_OUTDIR}/rapid-prereview-users.jsonl`,
+    await OSrPREImportUser(
+      userModel,
+      personaModel,
+      userMap,
+      personaMap,
+      anonMap,
+    ),
+  );
+  await processActions(
+    `${process.env.COUCH_OUTDIR}/rapid-prereview-docs.jsonl`,
+    await OSrPREImportRequest(requestModel, preprintModel, personaMap),
+    await OSrPREImportReview(
+      fullReviewModel,
+      preprintModel,
+      rapidReviewModel,
+      personaMap,
+    ),
+  );
+}
+
+main();


### PR DESCRIPTION
This splits out the database import scripts from the legacy sites into separate scripts for Prereview.org and Outbreak Science, and also makes the fetching of Couchdb backups from Outbreak automatic. To fully test, you'd run:
```
npm run build:scripts
npm run db:migrations
npm run db:init #optionally
npm run db:import
```
and make sure the records show up in the database, and or a local copy of the site. There are certain necessary environment variables that need to be defined, namely `IMPORT_{HOST,PORT,USER,PASS,DB}` for the postgres credentials for Prereview.org, and `COUCH_{HOST,PORT,USERNAME,PASSWORD,OUTDIR}` for the couchdb credentials for Outbreak Science and temp directory to store the temporary backup files.

This all takes a long time to run though and it's most important to test it in the staging environment, so if you could just make sure it builds and doesn't mess up the build, I can merge it to `main` to test it on Azure if that's cool.
