### PR TITLE
WIP: Enable mock ORCID login strategy

### DIFF
--- a/src/backend/utils/mockStrategy.js
+++ b/src/backend/utils/mockStrategy.js
@@ -22,9 +22,9 @@ export default class MockStrategy extends Strategy {
     const refreshToken = 'refreshToken';
     const params = {
       orcid: createRandomOrcid(),
-      username: 'anotherunique',
-      name: 'Test User',
-      email: 'bob@bob3.com',
+      username: 'uniqueUser',
+      name: 'Test Unique User',
+      email: 'bob@unique.com',
       isAdmin: false, // in dev mode we create admin users
       isModerator: true,
       expires_in: 20 * 365 * 24 * 60 * 60, // in secs


### PR DESCRIPTION
You'll have to add `PREREVIEW_ORCID_MOCK_STRATEGY=true` to your .env file to test this out. It currently still errors out before hitting the callback URL. 
