### PR TITLE
fix fallback for missing pdf and style data displayed instead

### DIFF
--- a/src/frontend/components/extension-fallback.js
+++ b/src/frontend/components/extension-fallback.js
@@ -39,6 +39,7 @@ export default function ExtensionFallback() {
 
   const [loading, setLoading] = useState(true);
   const [preprint, setPreprint] = useState(null);
+  const [authors, setAuthors] = useState(null);
 
   const { id } = useParams();
 
@@ -64,6 +65,14 @@ export default function ExtensionFallback() {
 
   const pdfUrl = preprint ? preprint.contentUrl : '';
   const canonicalUrl = getCanonicalUrl(preprint ? preprint : null);
+
+  useEffect(() => {
+    if (preprint) {
+      const string = preprint.authors.replace(/[|&;$%@"<>()\[\]+]/g, "");
+      setAuthors(string);
+    }
+
+  }, [preprint]);
 
   useEffect(() => {
     if (window) {
@@ -101,38 +110,31 @@ export default function ExtensionFallback() {
               // typemustmatch="true" commented out as it doesn't seem to be currently supported by react
             >
               {/* fallback text in case we can't load the PDF */}
-              <Suspense fallback={<SuspenseLoading>Loading PDF</SuspenseLoading>}>
-                <PdfViewer
-                  docId={id}
-                  loading={<SuspenseLoading>Loading PDF</SuspenseLoading>}
-                />
-              </Suspense>
+              <div className="extension-fallback__no-pdf-message">
+                <div className="extension-fallback__no-pdf-message-inner">
+                  <h2>{preprint.title}</h2>
+                  <div className="extension-fallback__no-pdf-message-inner-authors">{authors}</div>
+                  <h3>Abstract</h3>
+                  <div  className="extension-fallback__no-pdf-message-inner-content" dangerouslySetInnerHTML={{ __html: preprint.abstractText }} />
+                  {!!canonicalUrl && (
+                    <div  className="extension-fallback__no-pdf-message-inner-link">
+                      You can access the{' '}
+                      {
+                        <a
+                          href={canonicalUrl}
+                          target="_blank"
+                          rel="noreferrer noopener"
+                        >
+                          full text of this preprint
+                        </a>
+                      }{' '}
+                      at the preprint server's website.
+                    </div>
+                  )}
+                </div>
+              </div>
             </object>
           )
-        ) : preprint && !pdfUrl && !loadingPreprint ? (
-          <div className="extension-fallback__no-pdf-message">
-            <div>
-              <h2>{preprint.title}</h2>
-              <div>{preprint.author}</div>
-              <h3>Abstract</h3>
-              <div>{preprint.abstract}</div>
-              {!!canonicalUrl && (
-                <div>
-                  You can access the{' '}
-                  {
-                    <a
-                      href={canonicalUrl}
-                      target="_blank"
-                      rel="noreferrer noopener"
-                    >
-                      full text of this preprint
-                    </a>
-                  }{' '}
-                  at the preprint server's website.
-                </div>
-              )}
-            </div>
-          </div>
         ) : null}
 
         <Shell>

--- a/src/frontend/components/extension-fallback.js
+++ b/src/frontend/components/extension-fallback.js
@@ -93,8 +93,7 @@ export default function ExtensionFallback() {
           </title>
         </Helmet>
 
-        {pdfUrl ? (
-          isMobile || isChromeOnMac ? (
+        {isMobile || isChromeOnMac ? (
             /* for mobile devices we always use the fallback */
             <Suspense fallback={<SuspenseLoading>Loading PDF</SuspenseLoading>}>
               <PdfViewer
@@ -134,8 +133,7 @@ export default function ExtensionFallback() {
                 </div>
               </div>
             </object>
-          )
-        ) : null}
+          )}
 
         <Shell>
           {onRequireScreen =>

--- a/src/frontend/components/extension-fallback.scss
+++ b/src/frontend/components/extension-fallback.scss
@@ -4,17 +4,24 @@
   background-color: rgb(83, 86, 89);
 
   & .extension-fallback__no-pdf-message {
-    text-align: center;
-    padding: var(--sgrd);
-    display: flex;
-    justify-content: center;
     align-items: center;
+    background-color: #fff;
+    color: #000;
+    display: flex;
     height: 50vh;
-    color: white;
-    text-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
-    & a {
-      &:hover {
-        color: white;
+    justify-content: center;
+
+    &-inner {
+      padding: 3em;
+
+      &-authors, &-content, &-link {
+        font-size: 1rem;
+        // letter-spacing: 1.2;
+        line-height: 1.5;
+      }
+
+      &-link {
+        margin-top: 1rem;
       }
     }
   }

--- a/src/frontend/components/modal.scss
+++ b/src/frontend/components/modal.scss
@@ -8,6 +8,7 @@
 /* Note the rpos- prefix as modal is a common class in the host sites where the content script is injected */
 .rpos-modal-container {
   left: 50%;
+  margin: 0;
   max-width: 800px;
   min-width: 400px;
   position: fixed;

--- a/src/frontend/style.scss
+++ b/src/frontend/style.scss
@@ -11,11 +11,10 @@
 @import "./components/extension-splash.scss";
 @import "./components/extension-fallback.scss";
 
-/* etc */
+/* reach */
+@import "@reach/dialog/styles.css";
+@import "@reach/menu-button/styles.css";
 @import "@reach/tooltip/styles.css";
-
-/* remirror */
-@import 'remirror/styles/all.css';
 
 /* modules */
 @import "./components/home.scss";


### PR DESCRIPTION
This PR renders info about a preprint if there is no content to display from the pdf url. 

Fixes #119 

Good test DOIs are 10.1101/833392 and 10.3128/550