### PR TITLE
Integrating Plaudit.pub

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27600,6 +27600,15 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-async-script": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/react-async-script/-/react-async-script-1.2.0.tgz",
+      "integrity": "sha512-bCpkbm9JiAuMGhkqoAiC0lLkb40DJ0HOEJIku+9JDjxX3Rcs+ztEOG13wbrOskt3n2DTrjshhaQ/iay+SnGg5Q==",
+      "requires": {
+        "hoist-non-react-statics": "^3.3.0",
+        "prop-types": "^15.5.0"
+      }
+    },
     "react-avatar-editor": {
       "version": "11.0.13",
       "resolved": "https://registry.npmjs.org/react-avatar-editor/-/react-avatar-editor-11.0.13.tgz",

--- a/package.json
+++ b/package.json
@@ -203,6 +203,7 @@
     "prop-types": "^15.7.2",
     "quill": "^1.3.7",
     "react": "^16.12.0",
+    "react-async-script": "^1.2.0",
     "react-avatar-editor": "^11.0.12",
     "react-dnd": "^11.1.3",
     "react-dnd-html5-backend": "^11.1.3",

--- a/src/frontend/components/plaudit-script.js
+++ b/src/frontend/components/plaudit-script.js
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import makeAsyncScriptLoader from "react-async-script";
+
+const PLAUDITURL = 'https://plaudit.pub/embed/endorsements.js'
+const DATAATTR = { 'data-embedder-id': 'prereview' }
+
+const Plaudit = () => {
+  return <div>Endorsements</div>
+}
+
+export default function PlauditScript() {
+  const [isScriptLoaded, setIsScriptLoaded] = useState(false)
+
+  const handleScriptLoad = () => {
+    setIsScriptLoaded(true)
+  }
+
+  isScriptLoaded ? console.log('Plaudit.pub script loaded') : console.log('Plaudit nowhere to be found')
+
+  const loadingElement = () => {
+    return <div>Loading...</div>;
+  };
+
+  let AsyncScriptComponent;
+
+  isScriptLoaded ? AsyncScriptComponent = makeAsyncScriptLoader(PLAUDITURL, DATAATTR)(Plaudit) : AsyncScriptComponent = makeAsyncScriptLoader(PLAUDITURL, DATAATTR)(loadingElement)
+
+  return <AsyncScriptComponent asyncScriptOnLoad={handleScriptLoad} />
+}
+

--- a/src/frontend/components/review-reader-longform.js
+++ b/src/frontend/components/review-reader-longform.js
@@ -20,6 +20,7 @@ import CommentEditor from './comment-editor';
 import Controls from './controls';
 import ReportButton from './report-button';
 import RoleBadge from './role-badge';
+import PlauditScript from './plaudit-script';
 
 const Button = withStyles({
   root: {
@@ -239,7 +240,7 @@ const LongformReviewReader = props => {
                   justify="space-between"
                   spacing={2}
                 >
-                  <Grid item>Plaudit</Grid>
+                  <Grid item><PlauditScript /></Grid>
                   {/*#FIXME plaudits*/}
                   <Grid item>
                     <ReportButton reviewId={review.uuid} />

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -35,7 +35,6 @@
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <script id="entrypoint" src="./client.js"></script>
-    <script async src="https://plaudit.pub/embed/endorsements.js" data-embedder-id="prereview"></script>
 
     <!--
       This HTML file is a template.

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -35,6 +35,8 @@
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <script id="entrypoint" src="./client.js"></script>
+    <script async src="https://plaudit.pub/embed/endorsements.js" data-embedder-id="prereview"></script>
+
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.


### PR DESCRIPTION
I added the [NPM library `react-async-script`](https://www.npmjs.com/package/react-async-script) to load the Plaudit script. I'm not super sure if I used it correctly, so I would love your eyes on this! I can tell the `asyncScriptOnLoad` callback is fired, though, so there's that, but this isn't tested yet because I don't think the script recognizes the fake DOI on our seeded data (I believe the Plaudit endorsement button appears on your page if you have the Plaudit extension installed and the page's content has a DOI). Any ideas on a way to test? @jheretic @rudietuesdays 