### PR TITLE
fix collaborative editing so it's no longer *too collaborative*

### DIFF
--- a/src/frontend/components/collab-editor.js
+++ b/src/frontend/components/collab-editor.js
@@ -1,5 +1,5 @@
 // base imports
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
 // yjs imports
@@ -14,11 +14,14 @@ import 'quill/dist/quill.snow.css'; // Add css for snow theme
 // or import 'quill/dist/quill.bubble.css'; // Add css for bubble theme
 
 const ydoc = new Y.Doc();
-const provider = new WebrtcProvider('prereview-collab', ydoc);
 
-const CollabEditor = ({ initialContent, handleContentChange }) => {
+const CollabEditor = ({ initialContent, handleContentChange, reviewId }) => {
   /* collaboration needs */
-  // provider.connect();
+  const [provider, setProvider] = useState(null);
+
+  useEffect(() => {
+    setProvider(new WebrtcProvider(`prereview-${reviewId}`, ydoc));
+  }, []);
 
   // quill options
   const placeholder = 'Start typing...';
@@ -67,10 +70,6 @@ const CollabEditor = ({ initialContent, handleContentChange }) => {
     Quill.register('modules/cursors', QuillCursors);
   }
 
-  if (quill) {
-    // provider.connect();
-  }
-
   useEffect(() => {
     if (quill) {
       let delta;
@@ -104,6 +103,7 @@ const CollabEditor = ({ initialContent, handleContentChange }) => {
 CollabEditor.propTypes = {
   initialContent: PropTypes.string,
   handleContentChange: PropTypes.func.isRequired,
+  reviewId: PropTypes.string,
 };
 
 export default CollabEditor;

--- a/src/frontend/components/long-form-fragment.js
+++ b/src/frontend/components/long-form-fragment.js
@@ -4,7 +4,11 @@ import PropTypes from 'prop-types';
 // components
 import CollabEditor from './collab-editor';
 
-export default function LongFormFragment({ content, onContentChange }) {
+export default function LongFormFragment({
+  content,
+  onContentChange,
+  reviewId,
+}) {
   return (
     <div className="rapid-form-fragment">
       <fieldset className="rapid-form-fragment__text-response-questions">
@@ -12,6 +16,7 @@ export default function LongFormFragment({ content, onContentChange }) {
           <CollabEditor
             initialContent={content}
             handleContentChange={onContentChange}
+            reviewId={reviewId}
           />
         </Fragment>
       </fieldset>
@@ -22,4 +27,5 @@ export default function LongFormFragment({ content, onContentChange }) {
 LongFormFragment.propTypes = {
   content: PropTypes.string.isRequired,
   onContentChange: PropTypes.func.isRequired,
+  reviewId: PropTypes.string,
 };

--- a/src/frontend/components/review-stepper.js
+++ b/src/frontend/components/review-stepper.js
@@ -262,7 +262,6 @@ export default function ReviewStepper({
   const [reviewId, setReviewId] = useState(review ? review.parent : null);
   const [skipped, setSkipped] = useState(new Set());
   const steps = getSteps();
-  console.log(review);
   // API queries
   const { data: templates } = useGetTemplates();
   const { mutate: postRapidReview } = usePostRapidReviews();
@@ -493,7 +492,6 @@ export default function ReviewStepper({
   }
 
   useEffect(() => {
-    console.log(hasRapidReviewed);
     if (hasRapidReviewed) {
       handleComplete();
     }
@@ -590,10 +588,7 @@ export default function ReviewStepper({
               >
                 <Grid item xs={12} sm={6}>
                   <AddAuthors reviewId={cid} />
-                  <AddAuthors
-                    isMentor={true}
-                    reviewId={cid}
-                  />
+                  <AddAuthors isMentor={true} reviewId={cid} />
                 </Grid>
                 <Grid item xs={12} sm={6}>
                   <Box textAlign="right" mr={2}>
@@ -693,6 +688,7 @@ export default function ReviewStepper({
                     onContentChange={onContentChange}
                     content={content}
                     template={template}
+                    reviewId={cid}
                   />
                 </Box>
                 <Box mt={2}>


### PR DESCRIPTION
Now only authors/editors who are logged in and at the same URL with permissions to edit that review can see and edit it. Visiting the preprint page on its own will not allow for collaborative editing. The user will need to visit the full URL with the review ID.

For instance, `http://127.0.0.1:3000/preprints/doi-10.4861-701` will not be collaborative. `http://127.0.0.1:3000/preprints/doi-10.4861-701/reviews/e000b49b-fc46-49f0-9915-fc8c6946c7b8` will be collaborative.