### PR TITLE
Fixes to ensure users stay anonymous when submitting to Zenodo

### DIFF
--- a/src/frontend/components/shell.js
+++ b/src/frontend/components/shell.js
@@ -57,7 +57,10 @@ export default function Shell({ children, defaultStatus = 'default' }) {
     const host = window.location.host;
     const labels = host.split('.');
 
-    if (labels.length === 3 || (labels.length === 2 && labels[1].includes('localhost'))) {
+    if (
+      labels.length === 3 ||
+      (labels.length === 2 && labels[1].includes('localhost'))
+    ) {
       if (labels[0] === 'outbreaksci') {
         setLoginLink('https://prereview.org/login');
         setHomeLink('https://prereview.org');
@@ -266,7 +269,9 @@ export default function Shell({ children, defaultStatus = 'default' }) {
         <div className="shell__control-bar">
           <div className="shell__controls">
             <div className="shell__controls__left">
-              <Link to="/" href={homeLink}><PreReviewLogo short={true} /></Link>
+              <Link to="/" href={homeLink}>
+                <PreReviewLogo short={true} />
+              </Link>
             </div>
             <div className="shell__controls__center">
               <IconButton

--- a/src/frontend/components/shell.js
+++ b/src/frontend/components/shell.js
@@ -20,6 +20,9 @@ import NoticeBadge from './notice-badge';
 import UserBadge from './user-badge';
 import XLink from './xlink';
 
+// material-ui
+import Link from '@material-ui/core/Link';
+
 // icons
 import { MdDragHandle, MdUnfoldMore, MdUnfoldLess } from 'react-icons/md';
 import IconButton from './icon-button';
@@ -30,6 +33,8 @@ const SHELL_HEADER_HEIGHT = 40; // !! keep in sync with CSS
 export default function Shell({ children, defaultStatus = 'default' }) {
   const [user] = useContext(UserProvider.context);
   const [isDown, setIsDown] = useState(false);
+  const [homeLink, setHomeLink] = useState('/');
+
   const ref = useRef();
   const nextHeightRef = useRef(null);
   const needForRafRef = useRef(true);
@@ -47,6 +52,19 @@ export default function Shell({ children, defaultStatus = 'default' }) {
   // shell height is set in `%` units through the `max-height` CSS property
   const [height, setHeight] = useState(50);
   const [status, setStatus] = useState(defaultStatus);
+
+  useEffect(() => {
+    const host = window.location.host;
+    const labels = host.split('.');
+
+    if (labels.length === 3 || (labels.length === 2 && labels[1].includes('localhost'))) {
+      if (labels[0] === 'outbreaksci') {
+        setLoginLink('https://prereview.org/login');
+        setHomeLink('https://prereview.org');
+        console.debug('Subdomain found');
+      }
+    }
+  }, []);
 
   // reposition shell when user "drag" the handle
   useEffect(() => {
@@ -248,7 +266,7 @@ export default function Shell({ children, defaultStatus = 'default' }) {
         <div className="shell__control-bar">
           <div className="shell__controls">
             <div className="shell__controls__left">
-              <PreReviewLogo short={true} />
+              <Link to="/" href={homeLink}><PreReviewLogo short={true} /></Link>
             </div>
             <div className="shell__controls__center">
               <IconButton


### PR DESCRIPTION
Fixed the conditionals in the fullReview backend so that when a reviewer is anonymous we don't send an author object with an ORCID property to Zenodo. Part of the prior confusion on whether Zenodo lets you submit publications without an ORCID, it seems, is that Zenodo's API accepts `undefined` as a value for the ORCID property, but not an empty string, which gave us false signals as to what was okay. 