### PR TITLE
Plaudits fix

### DIFF
--- a/src/frontend/components/plaudit-script.js
+++ b/src/frontend/components/plaudit-script.js
@@ -24,7 +24,6 @@ export default function useScript(src) {
         // Create script
         script = document.createElement('script');
         script.src = src;
-        script.async = true;
         script.setAttribute('data-status', 'loading');
         script.setAttribute('data-embedder-id', 'prereview')
 
@@ -72,7 +71,7 @@ export default function useScript(src) {
     [src], // Only re-run effect if script src changes
   );
 
-  return status;
+  return <div>Endorsements</div>
 }
 
 

--- a/src/frontend/components/plaudit-script.js
+++ b/src/frontend/components/plaudit-script.js
@@ -1,30 +1,106 @@
-import React, { useState } from 'react';
-import makeAsyncScriptLoader from "react-async-script";
+import React, { useState, useEffect } from 'react';
+// import makeAsyncScriptLoader from 'react-async-script'; 
 
-const PLAUDITURL = 'https://plaudit.pub/embed/endorsements.js'
-const DATAATTR = { 'data-embedder-id': 'prereview' }
 
-const Plaudit = () => {
-  return <div>Endorsements</div>
+export default function useScript(src) {
+  // Keep track of script status ("idle", "loading", "ready", "error")
+
+  const [status, setStatus] = useState(src ? 'loading' : 'idle');
+
+  useEffect(
+    () => {
+      // Allow falsy src value if waiting on other data needed for
+      // constructing the script URL passed to this hook.
+
+      if (!src) {
+        setStatus('idle');
+        return;
+      }
+
+      // Fetch existing script element by src
+      let script = document.querySelector(`script[src="${src}"]`);
+
+      if (!script) {
+        // Create script
+        script = document.createElement('script');
+        script.src = src;
+        script.async = true;
+        script.setAttribute('data-status', 'loading');
+        script.setAttribute('data-embedder-id', 'prereview')
+
+        // Add script to document body
+        document.body.appendChild(script);
+
+        // Store status in attribute on script
+        // This can be read by other instances of this hook
+        const setAttributeFromEvent = event => {
+          script.setAttribute(
+            'data-status',
+
+            event.type === 'load' ? 'ready' : 'error',
+          );
+        };
+
+        script.addEventListener('load', setAttributeFromEvent);
+
+        script.addEventListener('error', setAttributeFromEvent);
+      } else {
+        // Grab existing script status from attribute and set to state.
+
+        setStatus(script.getAttribute('data-status'));
+      }
+
+      // Script event handler to update status in state
+      // Note: Even if the script already exists we still need to add
+      // event handlers to update the state for *this* hook instance.
+      const setStateFromEvent = event => {
+        setStatus(event.type === 'load' ? 'ready' : 'error');
+      };
+
+      // Add event listeners
+      script.addEventListener('load', setStateFromEvent);
+      script.addEventListener('error', setStateFromEvent);
+
+      // Remove event listeners on cleanup
+      return () => {
+        if (script) {
+          script.removeEventListener('load', setStateFromEvent);
+          script.removeEventListener('error', setStateFromEvent);
+        }
+      };
+    },
+    [src], // Only re-run effect if script src changes
+  );
+
+  return status;
 }
 
-export default function PlauditScript() {
-  const [isScriptLoaded, setIsScriptLoaded] = useState(false)
 
-  const handleScriptLoad = () => {
-    setIsScriptLoaded(true)
-  }
 
-  isScriptLoaded ? console.log('Plaudit.pub script loaded') : console.log('Plaudit nowhere to be found')
+// export default function PlauditScript() {
+//   const [isScriptLoaded, setIsScriptLoaded] = useState(false);
 
-  const loadingElement = () => {
-    return <div>Loading...</div>;
-  };
+//   const handleScriptLoad = () => {
+//     setIsScriptLoaded(true);
+//   };
 
-  let AsyncScriptComponent;
+//   isScriptLoaded
+//     ? console.log('Plaudit.pub script loaded')
+//     : console.log('Plaudit nowhere to be found');
 
-  isScriptLoaded ? AsyncScriptComponent = makeAsyncScriptLoader(PLAUDITURL, DATAATTR)(Plaudit) : AsyncScriptComponent = makeAsyncScriptLoader(PLAUDITURL, DATAATTR)(loadingElement)
+//   const loadingElement = () => {
+//     return <div>Loading...</div>;
+//   };
 
-  return <AsyncScriptComponent asyncScriptOnLoad={handleScriptLoad} />
-}
+//   let AsyncScriptComponent;
 
+//   isScriptLoaded
+//     ? (AsyncScriptComponent = makeAsyncScriptLoader(PLAUDITURL, DATA_ATTR)(
+//         Plaudit,
+//       ))
+//     : (AsyncScriptComponent = makeAsyncScriptLoader(PLAUDITURL, DATA_ATTR)(
+//         loadingElement,
+//       ));
+
+//   return <AsyncScriptComponent asyncScriptOnLoad={handleScriptLoad} />;
+// }

--- a/src/frontend/components/plaudit-script.js
+++ b/src/frontend/components/plaudit-script.js
@@ -35,17 +35,14 @@ export default function useScript(src) {
         const setAttributeFromEvent = event => {
           scriptTag.setAttribute(
             'data-status',
-
             event.type === 'load' ? 'ready' : 'error',
           );
         };
 
         scriptTag.addEventListener('load', setAttributeFromEvent);
-
         scriptTag.addEventListener('error', setAttributeFromEvent);
       } else {
         // Grab existing script status from attribute and set to state.
-
         setStatus(scriptTag.getAttribute('data-status'));
       }
 
@@ -71,35 +68,5 @@ export default function useScript(src) {
     [src], // Only re-run effect if script src changes
   );
 
-  return <div>Endorsements</div>
+  return <p>Endorsements</p>
 }
-
-
-
-// export default function PlauditScript() {
-//   const [isScriptLoaded, setIsScriptLoaded] = useState(false);
-
-//   const handleScriptLoad = () => {
-//     setIsScriptLoaded(true);
-//   };
-
-//   isScriptLoaded
-//     ? console.log('Plaudit.pub script loaded')
-//     : console.log('Plaudit nowhere to be found');
-
-//   const loadingElement = () => {
-//     return <div>Loading...</div>;
-//   };
-
-//   let AsyncScriptComponent;
-
-//   isScriptLoaded
-//     ? (AsyncScriptComponent = makeAsyncScriptLoader(PLAUDITURL, DATA_ATTR)(
-//         Plaudit,
-//       ))
-//     : (AsyncScriptComponent = makeAsyncScriptLoader(PLAUDITURL, DATA_ATTR)(
-//         loadingElement,
-//       ));
-
-//   return <AsyncScriptComponent asyncScriptOnLoad={handleScriptLoad} />;
-// }

--- a/src/frontend/components/plaudit-script.js
+++ b/src/frontend/components/plaudit-script.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
-// import makeAsyncScriptLoader from 'react-async-script'; 
 
+// with thanks to https://usehooks.com/useScript/  
 
 export default function useScript(src) {
   // Keep track of script status ("idle", "loading", "ready", "error")

--- a/src/frontend/components/plaudit-script.js
+++ b/src/frontend/components/plaudit-script.js
@@ -18,35 +18,35 @@ export default function useScript(src) {
       }
 
       // Fetch existing script element by src
-      let script = document.querySelector(`script[src="${src}"]`);
+      let scriptTag = document.querySelector(`script[src="${src}"]`);
 
-      if (!script) {
-        // Create script
-        script = document.createElement('script');
-        script.src = src;
-        script.setAttribute('data-status', 'loading');
-        script.setAttribute('data-embedder-id', 'prereview')
+      if (!scriptTag) {
+        scriptTag = document.createElement('script');
+        scriptTag.src = src;
+        scriptTag.setAttribute('data-status', 'loading');
+        scriptTag.setAttribute('data-embedder-id', 'prereview');
 
-        // Add script to document body
-        document.body.appendChild(script);
+        let plauditDiv = document.getElementById('plaudits-div')
+
+        plauditDiv ? plauditDiv.appendChild(scriptTag) : document.body.appendChild(scriptTag)
 
         // Store status in attribute on script
         // This can be read by other instances of this hook
         const setAttributeFromEvent = event => {
-          script.setAttribute(
+          scriptTag.setAttribute(
             'data-status',
 
             event.type === 'load' ? 'ready' : 'error',
           );
         };
 
-        script.addEventListener('load', setAttributeFromEvent);
+        scriptTag.addEventListener('load', setAttributeFromEvent);
 
-        script.addEventListener('error', setAttributeFromEvent);
+        scriptTag.addEventListener('error', setAttributeFromEvent);
       } else {
         // Grab existing script status from attribute and set to state.
 
-        setStatus(script.getAttribute('data-status'));
+        setStatus(scriptTag.getAttribute('data-status'));
       }
 
       // Script event handler to update status in state
@@ -57,14 +57,14 @@ export default function useScript(src) {
       };
 
       // Add event listeners
-      script.addEventListener('load', setStateFromEvent);
-      script.addEventListener('error', setStateFromEvent);
+      scriptTag.addEventListener('load', setStateFromEvent);
+      scriptTag.addEventListener('error', setStateFromEvent);
 
       // Remove event listeners on cleanup
       return () => {
-        if (script) {
-          script.removeEventListener('load', setStateFromEvent);
-          script.removeEventListener('error', setStateFromEvent);
+        if (scriptTag) {
+          scriptTag.removeEventListener('load', setStateFromEvent);
+          scriptTag.removeEventListener('error', setStateFromEvent);
         }
       };
     },

--- a/src/frontend/components/review-reader-longform.js
+++ b/src/frontend/components/review-reader-longform.js
@@ -20,7 +20,9 @@ import CommentEditor from './comment-editor';
 import Controls from './controls';
 import ReportButton from './report-button';
 import RoleBadge from './role-badge';
-import PlauditScript from './plaudit-script';
+import useScript from './plaudit-script';
+
+const PLAUDITURL = 'https://plaudit.pub/embed/endorsements.js';
 
 const Button = withStyles({
   root: {
@@ -134,6 +136,10 @@ const LongformReviewReader = props => {
     transform,
   };
 
+  const Plaudits = () => {
+    return useScript(PLAUDITURL)
+  }
+
   // comments
   const {
     mutate: postComment,
@@ -246,7 +252,7 @@ const LongformReviewReader = props => {
                   justify="space-between"
                   spacing={2}
                 >
-                  <Grid item><PlauditScript /></Grid>
+                  <Grid item><Plaudits /></Grid>
                   {/*#FIXME plaudits*/}
                   <Grid item>
                     <ReportButton uuid={review.uuid} type='fullReview' />

--- a/src/frontend/components/review-reader-longform.js
+++ b/src/frontend/components/review-reader-longform.js
@@ -237,12 +237,17 @@ const LongformReviewReader = props => {
                 <Grid item xs={12} sm={3} className={classes.date}>
                   {reviewDate.toLocaleDateString('en-US')}
                 </Grid>
-               { review.doi ? 
-                <Grid item xs={12} sm={2}> 
-                  <a href={`https://doi.org/${review.doi}`}>
-                  <img src={`https://sandbox.zenodo.org/badge/DOI/${review.doi}.svg`}/></a> 
-                </Grid> 
-                : null }
+                {review.doi ? (
+                  <Grid item xs={12} sm={2}>
+                    <a href={`https://doi.org/${review.doi}`}>
+                      <img
+                        src={`https://sandbox.zenodo.org/badge/DOI/${
+                          review.doi
+                        }.svg`}
+                      />
+                    </a>
+                  </Grid>
+                ) : null}
               </Grid>
               <Box border="1px solid #E5E5E5" mt={4} px={3} pb={2}>
                 <Box>{ReactHtmlParser(reviewContent.contents, options)}</Box>
@@ -252,10 +257,14 @@ const LongformReviewReader = props => {
                   justify="space-between"
                   spacing={2}
                 >
-                  <Grid item><Plaudits /></Grid>
+                  <Grid item>
+                    <div id="plaudits-div">
+                      <Plaudits />
+                    </div>
+                  </Grid>
                   {/*#FIXME plaudits*/}
                   <Grid item>
-                    <ReportButton uuid={review.uuid} type='fullReview' />
+                    <ReportButton uuid={review.uuid} type="fullReview" />
                   </Grid>
                 </Grid>
               </Box>

--- a/src/frontend/components/review-reader-longform.js
+++ b/src/frontend/components/review-reader-longform.js
@@ -241,7 +241,7 @@ const LongformReviewReader = props => {
                   <Grid item xs={12} sm={2}>
                     <a href={`https://doi.org/${review.doi}`}>
                       <img
-                        src={`https://sandbox.zenodo.org/badge/DOI/${
+                        src={`https://zenodo.org/badge/DOI/${
                           review.doi
                         }.svg`}
                       />


### PR DESCRIPTION
Hi! This is an attempt to fix #208. I initially attempted to implement the Plaudits script integration with the `react-async-script` library, but found the code kind of unreadable and difficult to troubleshoot. I decided to borrow from https://usehooks.com/useScript/ and implement it using a custom hook. This still needs to be merged with the staging site to actually test, but upon inspection, the script tag did indeed get appended to the correct `div` element. 

The expected behavior is for the iframe below, as seen on bioRxiv, to show up where we've appended the script tag. 
![Screen Shot 2021-03-20 at 11 38 43](https://user-images.githubusercontent.com/13320420/111875565-db171e80-8970-11eb-878b-5b45136e4217.png)
