### PR TITLE
Properly inline orcid and contacts for public personas.

### DIFF
--- a/src/backend/controllers/docs.js
+++ b/src/backend/controllers/docs.js
@@ -34,7 +34,7 @@ export default function docs(authz) {
   generator.addJoiRouter(groupRoutes({}, {}, authz));
   generator.addJoiRouter(commentRoutes({}, {}, authz));
   generator.addJoiRouter(communityRoutes({}, {}, {}, {}, {}, authz));
-  generator.addJoiRouter(personaRoutes({}, {}, {}, authz));
+  generator.addJoiRouter(personaRoutes({}, {}, {}, {}, authz));
   generator.addJoiRouter(rapidReviewRoutes({}, {}, authz));
   generator.addJoiRouter(reportRoutes({}, {}, {}, {}, {}, authz));
   generator.addJoiRouter(requestRoutes({}, {}, authz));

--- a/src/backend/controllers/user.js
+++ b/src/backend/controllers/user.js
@@ -111,6 +111,7 @@ export default function controller(users, contacts, keys, thisUser) {
 
         let avatar;
         if (
+          user.defaultPersona &&
           user.defaultPersona.avatar &&
           Buffer.isBuffer(user.defaultPersona.avatar)
         ) {

--- a/src/backend/scripts/genSpec.js
+++ b/src/backend/scripts/genSpec.js
@@ -35,7 +35,7 @@ function docs() {
   generator.addJoiRouter(badgeRoutes({}, authz));
   generator.addJoiRouter(expertiseRoutes({}, authz));
   generator.addJoiRouter(communityRoutes({}, {}, {}, {}, {}, authz));
-  generator.addJoiRouter(personaRoutes({}, {}, {}, authz));
+  generator.addJoiRouter(personaRoutes({}, {}, {}, {}, authz));
   generator.addJoiRouter(rapidReviewRoutes({}, {}, authz));
   generator.addJoiRouter(reportRoutes({}, {}, {}, {}, {}, authz));
   generator.addJoiRouter(requestRoutes({}, {}, authz));

--- a/src/backend/server.js
+++ b/src/backend/server.js
@@ -148,6 +148,7 @@ export default async function configServer(config) {
   const groups = GroupController(groupModel, userModel, authz);
   const personas = PersonaController(
     personaModel,
+    userModel,
     badgeModel,
     expertiseModel,
     authz,

--- a/src/frontend/components/profile.js
+++ b/src/frontend/components/profile.js
@@ -206,18 +206,14 @@ export default function Profile() {
   const [name, setName] = useState('');
   const orcid = ownProfile
     ? thisUser.orcid
-    : displayedPersona &&
-      !displayedPersona.isAnonymous &&
-      displayedPersona.identity
-    ? displayedPersona.identity.orcid
+    : displayedPersona && !displayedPersona.isAnonymous
+    ? displayedPersona.orcid
     : '';
   const [contacts, setContacts] = useState(
     ownProfile
       ? thisUser.contacts
-      : displayedPersona &&
-        !displayedPersona.isAnonymous &&
-        displayedPersona.identity
-      ? displayedPersona.identity.contacts
+      : displayedPersona && !displayedPersona.isAnonymous
+      ? displayedPersona.contacts
       : [],
   );
   const badges =


### PR DESCRIPTION
This should fix a couple of display issues in the new profiles, by properly inline the orcid and contacts from the associated user object when viewing a public persona. This puts them in the top-level persona object returned from the API. The profile page has been updated accordingly, but could probably use a bit more testing to make sure the contacts are being loaded correctly.