### PR TITLE
Preprint resolution fixes

### DIFF
--- a/src/backend/utils/resolve.ts
+++ b/src/backend/utils/resolve.ts
@@ -95,7 +95,7 @@ async function scrapeUrl(
       authors: authors,
       datePosted: datePosted
         ? new Date(datePosted as string).toISOString()
-        : null,
+        : new Date().toISOString(),
       license: null,
       publication: highwirePress.publisher ? highwirePress.publisher : null,
       contentUrl: highwirePress.pdf_url ? highwirePress.pdf_url : null,

--- a/src/backend/utils/resolve.ts
+++ b/src/backend/utils/resolve.ts
@@ -77,6 +77,17 @@ async function scrapeUrl(
       ? highwirePress.date
       : undefined;
 
+    const publication = highwirePress.publisher
+      ? highwirePress.publisher
+      : undefined;
+
+    let preprintServer =
+      openGraph && openGraph.site_name ? openGraph.site_name : undefined;
+
+    if (!preprintServer && publication === 'Preprints') {
+      preprintServer = publication;
+    }
+
     const preprint: PreprintMetadata = {
       handle: `${handleType}:${handle}`,
       title: highwirePress.title ? highwirePress.title : undefined,
@@ -89,20 +100,13 @@ async function scrapeUrl(
           ? general.description
           : undefined,
       url: openGraph && openGraph.url ? openGraph.url : undefined,
-      preprintServer:
-        openGraph && openGraph.site_name
-          ? openGraph.site_name
-          : highwirePress.public_url
-          ? highwirePress.public_url
-          : undefined,
+      preprintServer: preprintServer,
       authors: authors.length > 0 ? authors : undefined,
       datePosted: datePosted
         ? new Date(datePosted as string).toISOString()
         : new Date().toISOString(),
       license: undefined,
-      publication: highwirePress.publisher
-        ? highwirePress.publisher
-        : undefined,
+      publication: publication,
       contentUrl: highwirePress.pdf_url ? highwirePress.pdf_url : undefined,
       contentEncoding: highwirePress.pdf_url ? 'application/pdf' : undefined,
     };

--- a/src/common/utils/ids.js
+++ b/src/common/utils/ids.js
@@ -40,7 +40,7 @@ export function createPreprintId(
     );
   }
 
-  return `${vendor}-${unprefix(id).replace('/', '-')}`;
+  return `${vendor}-${unprefix(id).replace(/\//g, '-')}`;
 }
 
 export function decodePreprintId(value) {
@@ -62,7 +62,7 @@ export function decodePreprintId(value) {
   }
 
   return {
-    id: `${value.slice(value.indexOf('-') + 1).replace('-', '/')}`,
+    id: `${value.slice(value.indexOf('-') + 1).replace(/-/g, '/')}`,
     scheme: scheme,
   };
 }

--- a/src/frontend/utils/preprints.js
+++ b/src/frontend/utils/preprints.js
@@ -73,8 +73,9 @@ export function getCanonicalUrl(preprint = {}) {
  * Used to avoid converting date posted to user locale
  */
 export function getFormattedDatePosted(isoString) {
+  isoString = isoString ? isoString : new Date().toISOString();
   const [year, month, day] = isoString.substr(0, 10).split('-');
-  return format(new Date(year, month-1, day), 'yyyy/MM/dd');
+  return format(new Date(year, month - 1, day), 'yyyy/MM/dd');
 }
 
 /**


### PR DESCRIPTION
This refactors the preprint resolver so that all resolvers run in parallel and merge results. It also includes some fixes to better handle inconsistent usage of metadata across different preprint servers, notably Crossref data from Preprints.org and AfricarXiv.

Fixes #306
Fixes #334 

To test, try requesting the preprints from the issues above. Note that with the ones above, the PDF still won't display due to circumstances beyond our control.