### PR TITLE
Additional community fixes

### DIFF
--- a/src/backend/controllers/rapidReview.js
+++ b/src/backend/controllers/rapidReview.js
@@ -71,20 +71,9 @@ export default function controller(rapidReviews, preprints, thisUser) {
           query = queries[0];
         }
         log.debug('Querying rapid reviews:', query);
-        [data, count] = await rapidReviews.findAndCount(
-          query,
-          ['author', 'preprint'],
-          { createdAt: order },
-          ctx.query.limit,
-          ctx.query.offset,
-        );
+        [data, count] = await rapidReviews.findAndCount(query, options);
       } else {
-        data = await rapidReviews.findAll(
-          ['author', 'preprint'],
-          { createdAt: order },
-          ctx.query.limit,
-          ctx.query.offset,
-        );
+        data = await rapidReviews.findAll(options);
         count = await rapidReviews.count();
       }
     } catch (err) {

--- a/src/backend/db/migrations/postgresql/Migration20210506144030.ts
+++ b/src/backend/db/migrations/postgresql/Migration20210506144030.ts
@@ -1,0 +1,7 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20210506144030 extends Migration {
+  async up(): Promise<void> {
+    this.addSql('alter table "event" add column "url" text null;');
+  }
+}

--- a/src/backend/db/migrations/postgresql/index.ts
+++ b/src/backend/db/migrations/postgresql/index.ts
@@ -10,3 +10,4 @@ export * from "./Migration20210324151516";
 export * from "./Migration20210328224443";
 export * from "./Migration20210330003825";
 export * from "./Migration20210409140547";
+export * from "./Migration20210506144030";

--- a/src/backend/db/migrations/sqlite/Migration20210506132046.ts
+++ b/src/backend/db/migrations/sqlite/Migration20210506132046.ts
@@ -1,0 +1,7 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20210506132046 extends Migration {
+  async up(): Promise<void> {
+    this.addSql('alter table `event` add column `url` text null;');
+  }
+}

--- a/src/backend/db/migrations/sqlite/index.ts
+++ b/src/backend/db/migrations/sqlite/index.ts
@@ -9,3 +9,4 @@ export * from "./Migration20210324135635";
 export * from "./Migration20210328223715";
 export * from "./Migration20210330003233";
 export * from "./Migration20210409140433";
+export * from "./Migration20210506132046";

--- a/src/backend/models/communities.ts
+++ b/src/backend/models/communities.ts
@@ -9,27 +9,50 @@ const log = getLogger('backend:models:communities');
 @Repository(Community)
 export class CommunityModel extends EntityRepository<Community> {
   async isMemberOf(communityId: string, userId: string): Promise<boolean> {
-    let community: any;
-    if (uuidValidate(communityId)) {
-      community = await this.findOne({ uuid: communityId }, ['members']);
-    } else {
-      community = await this.findOne({ slug: communityId }, ['members']);
+    let user: any;
+    if (orcidUtils.isValid(userId)) {
+      user = await this.em.findOne(User, { orcid: userId as string }, [
+        'personas',
+      ]);
+    } else if (uuidValidate(userId)) {
+      user = await this.em.findOne(User, { uuid: userId as string }, [
+        'personas',
+      ]);
     }
 
-    if (!community) {
-      log.warn(`No such community ${communityId}`);
+    if (!user) {
+      log.warn(`No such user ${communityId}`);
       return false;
     }
 
-    let user: any;
-    if (orcidUtils.isValid(userId)) {
-      user = await this.em.findOne(User, { orcid: userId as string });
-    } else if (uuidValidate(userId)) {
-      user = await this.em.findOne(User, { uuid: userId as string });
+    const personas = await user.personas
+      .getItems()
+      .map(persona => persona.uuid);
+
+    let community: any;
+    if (uuidValidate(communityId)) {
+      community = await this.findOne(
+        {
+          $and: [
+            { uuid: communityId },
+            { members: { uuid: { $in: personas } } },
+          ],
+        },
+        ['members'],
+      );
+    } else {
+      community = await this.findOne(
+        {
+          $and: [
+            { slug: communityId },
+            { members: { uuid: { $in: personas } } },
+          ],
+        },
+        ['members'],
+      );
     }
 
-    if (!user) return false;
-    return community.members.contains(user);
+    return !!community;
   }
 
   async isOwnerOf(communityId: string, userId: string): Promise<boolean> {

--- a/src/backend/models/entities/Event.ts
+++ b/src/backend/models/entities/Event.ts
@@ -34,6 +34,10 @@ export class Event extends BaseEntity {
   @Property({ columnType: 'text', nullable: true })
   description?: string;
 
+  @Fixture(faker => faker.internet.url())
+  @Property({ columnType: 'text', nullable: true })
+  url?: string;
+
   @ManyToOne({ entity: () => Community, nullable: true })
   community?: Community;
 

--- a/src/frontend/components/Communities.js
+++ b/src/frontend/components/Communities.js
@@ -153,7 +153,7 @@ const Communities = () => {
               />
 
               <Grid container spacing={4}>
-                <Grid item xs={12} md={8}>
+                <Grid item xs={12} md={12}>
                   {communities && communities.totalCount === 0 && !loading ? (
                     <div>No communities found.</div>
                   ) : (
@@ -186,6 +186,7 @@ const Communities = () => {
                     </div>
                   )}
                 </Grid>
+                {/*
                 <Grid item xs={12} md={4} className={classes.smallColumn}>
                   <Typography variant="h5" component="h2" gutterBottom={true}>
                     Search communities by tag
@@ -209,6 +210,7 @@ const Communities = () => {
                     </Box>
                   </Typography>
                 </Grid>
+                  */}
               </Grid>
             </Box>
           </Container>

--- a/src/frontend/components/Event.js
+++ b/src/frontend/components/Event.js
@@ -16,9 +16,9 @@ import Loading from './loading';
 import NotFound from './not-found';
 
 // Material-ui components
-import { makeStyles } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import Container from '@material-ui/core/Container';
+import Link from '@material-ui/core/Link';
 import Typography from '@material-ui/core/Typography';
 
 // constants
@@ -73,6 +73,11 @@ const Event = () => {
                   }).format(Date.parse(evt.start))
                 : ''}
             </Typography>
+            {evt && evt.url && (
+              <Typography variant="body1" component="div">
+                <Link href={evt.url}>{evt.url}</Link>
+              </Typography>
+            )}
             <Typography variant="body1" component="div">
               {evt ? evt.description : ''}
             </Typography>

--- a/src/frontend/components/add-authors.js
+++ b/src/frontend/components/add-authors.js
@@ -12,14 +12,12 @@ import Modal from '@material-ui/core/Modal';
 import MuiButton from '@material-ui/core/Button';
 import MuiTooltip from '@material-ui/core/Tooltip';
 
-
 // hooks
 import { useGetPersonas } from '../hooks/api-hooks.tsx';
 
 // components
 import Search from './search';
 import NotFound from './not-found';
-
 
 // icons
 import AddCircleOutlineIcon from '@material-ui/icons/AddCircleOutline';
@@ -63,7 +61,7 @@ const AddAuthors = ({ isMentor, reviewId, members, membersLimit = 5 }) => {
   const classes = useStyles();
 
   // fetch users from API
-  const { data: users, loading: loading } = useGetPersonas({
+  const { data: users, loading: loading, error } = useGetPersonas({
     queryParams: {
       include_images: 'avatar',
     },
@@ -82,8 +80,8 @@ const AddAuthors = ({ isMentor, reviewId, members, membersLimit = 5 }) => {
 
   if (loading) {
     return <CircularProgress className={classes.spinning} />;
-  } else if (personasError) {
-    return <NotFound />
+  } else if (error) {
+    return <NotFound />;
   } else {
     return (
       <div>

--- a/src/frontend/components/add-event.js
+++ b/src/frontend/components/add-event.js
@@ -1,6 +1,7 @@
 // base imports
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
+import isURL from 'validator/lib/isURL';
 
 // material ui imports
 import { makeStyles, withStyles } from '@material-ui/core/styles';
@@ -115,9 +116,13 @@ const AddEvent = ({ community, addEvent }) => {
   /* validation */
   const canSubmit = () => {
     if (inputs.title && inputs.description && inputs.start) {
+      if (inputs.url && !isURL(inputs.url)) {
+        alert('The event link must be a valid URL.');
+        return false;
+      }
       return true;
     } else {
-      alert('All fields are required.');
+      alert('Please fill out required fields.');
       return false;
     }
   };
@@ -126,7 +131,7 @@ const AddEvent = ({ community, addEvent }) => {
     if (canSubmit()) {
       addCommunityEvent(inputs)
         .then(resp => {
-          addEvent({...inputs, uuid: resp.data.uuid});
+          addEvent({ ...inputs, uuid: resp.data.uuid });
           handleClose();
         })
         .then(() => {
@@ -186,6 +191,14 @@ const AddEvent = ({ community, addEvent }) => {
               variant="outlined"
               multiline
               rows={4}
+              className={classes.textField}
+              onChange={handleInputChange}
+            />
+            <TextField
+              id="url"
+              name="url"
+              label="Link"
+              variant="outlined"
               className={classes.textField}
               onChange={handleInputChange}
             />

--- a/src/frontend/components/add-user.js
+++ b/src/frontend/components/add-user.js
@@ -48,14 +48,13 @@ const useStyles = makeStyles(theme => ({
 const AddUsers = ({ community, isModerator, addUser }) => {
   const classes = useStyles();
 
-  const [users, setUsers] = useState(null);
-
   /* API calls */
   // fetch users from API
-  const { data: usersData, loading } = useGetPersonas({
-    queryParams: {
-      include_images: 'avatar',
-    },
+  const { data: users, loading, error } = useGetPersonas({
+    resolve: res =>
+      res.data.filter(
+        value => !community.members.some(member => member.uuid === value.uuid),
+      ),
   });
 
   // getModalStyle is not a pure function, we roll the style only on the first render
@@ -70,17 +69,9 @@ const AddUsers = ({ community, isModerator, addUser }) => {
     setOpen(false);
   };
 
-  useEffect(() => {
-    if (!loading) {
-      if (usersData) {
-        setUsers(usersData.data);
-      }
-    }
-  }, [usersData, loading]);
-
   if (loading) {
     return <CircularProgress className={classes.spinning} />;
-  } else if (personasError) {
+  } else if (error) {
     return <NotFound />;
   } else {
     return (

--- a/src/frontend/components/community-panel.js
+++ b/src/frontend/components/community-panel.js
@@ -20,7 +20,7 @@ import {
 
 // components
 import AddEvent from './add-event';
-import AddTag from './add-tag';
+//import AddTag from './add-tag';
 import AddUser from './add-user';
 import HeaderBar from './header-bar';
 import Loading from './loading';
@@ -405,6 +405,7 @@ const CommunityPanel = () => {
                     })
                   : null}
               </Box>
+              {/*
               <Box mb={4}>
                 <Typography variant="h4" component="h2" gutterBottom={true}>
                   Tags
@@ -423,6 +424,7 @@ const CommunityPanel = () => {
                     })
                   : null}
               </Box>
+                */}
               <Box mb={4}>
                 <Typography variant="h4" component="h2" gutterBottom={true}>
                   Templates

--- a/src/frontend/components/new-preprint.js
+++ b/src/frontend/components/new-preprint.js
@@ -31,7 +31,7 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-export default function NewPreprint({ user, onCancel }) {
+export default function NewPreprint({ user, onCancel, community }) {
   const location = useLocation(); // location.state can be {preprint, tab, isSingleStep} with tab being `request` or `review` (so that we know on which tab the shell should be activated with
   const qs = new URLSearchParams(location.search);
 
@@ -56,6 +56,7 @@ export default function NewPreprint({ user, onCancel }) {
     identifier,
     location.state && location.state.preprint,
     url,
+    community,
   );
 
   return (

--- a/src/frontend/components/search.js
+++ b/src/frontend/components/search.js
@@ -164,10 +164,12 @@ const Search = ({
     defaultValue: [],
     multiple: true,
     options: users,
-    getOptionLabel: option =>
-      option.defaultPersona
+    getOptionLabel: option => {
+      const label = option.defaultPersona
         ? option.defaultPersona.name || option.defaultPersona.orcid
-        : option.name || option.orcid,
+        : option.name || option.orcid;
+      return label ? label : 'Unknown';
+    },
   });
 
   const [disabledSubmit, setDisabledSubmit] = useState(true);
@@ -190,8 +192,8 @@ const Search = ({
             }
             throw new Error(response.message);
           })
-          .then(result => {
-            handleClose(result.data);
+          .then(() => {
+            handleClose(user);
             alert('Moderator(s) successfully added to community.');
             return;
           })
@@ -252,7 +254,7 @@ const Search = ({
               <Tag
                 key={`tag-${index}`}
                 label={
-                  option.defaultPersona
+                  option.defaultPersona && option.defaultPersona.name
                     ? option.defaultPersona.name
                     : option.name
                     ? option.name
@@ -273,7 +275,7 @@ const Search = ({
                 {...getOptionProps({ option, index })}
               >
                 <span>
-                  {option.defaultPersona
+                  {option.defaultPersona && option.defaultPersona.name
                     ? option.defaultPersona.name
                     : option.name
                     ? option.name


### PR DESCRIPTION
This fixes numerous regressions with community administration, and adds some addtional tweaks. Namely:
* Better input validation in the search component, meaning it's possible to correctly add and delete members and moderators, with correct frontend state transitions.
* Available users to add only includes non-members, so it's not possible to receive an error by trying to re-add a user.
* Temporarily removed tags from community admin panel and from the communities search page.
* There was a regression where the community wasn't correctly getting passed to the add-button component. That's now fixed, so preprints added from the community page should get added to the current community.
* Add a 'Link' field for adding a link to the event, with frontend and backend input validation.
* Events marked as isPrivate should now only show up in the listing for community members and admins.
* The twitter field can now hold either a handle or a hashtag, and both displays and links accordingly.

Fixes #157
Fixes #329

In addition, the following issues are fixed via the just merged performance enhancements, and can be tested at the same time:
#324
#330
#354
#356